### PR TITLE
Add HACS metadata file for Child Medication Dosage card

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "Child Medication Dosage",
+  "content_in_root": false,
+  "render_readme": true,
+  "homeassistant": "2024.1.0",
+  "filename": "child-dosage-card.js"
+}


### PR DESCRIPTION
### Motivation
- Add HACS manifest so the frontend card can be discovered and installed via HACS and to declare compatibility with Home Assistant.

### Description
- Add `hacs.json` containing metadata (`name`, `content_in_root`, `render_readme`, `homeassistant`, `filename`) pointing to `child-dosage-card.js` and targeting Home Assistant `2024.1.0`.

### Testing
- No automated tests were added or run for this metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe08f996bc83299a0d222ac45fb0a4)