### PR TITLE
Add 48-hour dose log and show it when tapping the dosage bar

### DIFF
--- a/custom_components/child_medication_dosage/frontend/child-dosage-card.js
+++ b/custom_components/child_medication_dosage/frontend/child-dosage-card.js
@@ -31,7 +31,7 @@ class ChildDosageCard extends HTMLElement {
         button { border: 0; border-radius: 8px; min-height: 36px; padding: 8px 10px; font: inherit; font-weight: 600; color: #fff; background: var(--primary-color); }
         button.dose { width: 88px; height: 88px; padding: 8px; }
         button.reset { min-height: 32px; padding: 6px 8px; font-size: 12px; background: var(--error-color, #d32f2f); }
-        .bar { position: relative; height: 12px; border-radius: 6px; overflow: hidden; background: var(--divider-color); }
+        .bar { position: relative; height: 12px; border-radius: 6px; overflow: hidden; background: var(--divider-color); cursor: pointer; }
         .fill { position: absolute; inset: 0 auto 0 0; width: var(--fill-width); background: var(--bar-color); }
         .warning { color: var(--error-color, #d32f2f); font-size: 16px; font-weight: 700; display: flex; align-items: center; justify-content: center; gap: 8px; min-height: 36px; }
         .label { font-weight: 700; color: var(--primary-text-color); }
@@ -76,6 +76,7 @@ class ChildDosageCard extends HTMLElement {
 
     this._content.querySelectorAll("button[data-dose]").forEach((b) => b.addEventListener("click", () => this._giveDose(b.dataset.dose, b)));
     this._content.querySelectorAll("button[data-reset]").forEach((b) => b.addEventListener("click", () => this._resetDose(b.dataset.reset, b)));
+    this._content.querySelectorAll(".bar[data-log]").forEach((bar) => bar.addEventListener("click", () => this._showDoseLog(bar.dataset.log)));
   }
 
   _medicineTemplate(medicine, item) {
@@ -92,7 +93,7 @@ class ChildDosageCard extends HTMLElement {
       <div class="row">
         <div class="details">
           <div class="top"><b>${label}</b><span>${a.doses_24h || 0}/${a.max_doses_24h || 0} doses</span></div>
-          <div class="bar"><div class="fill" style="--fill-width:${fillWidth}%; --bar-color:${barColor}"></div></div>
+          <div class="bar" data-log='${this._escape(JSON.stringify(a.dose_log_48h || []))}' title="Show last 48h dose log"><div class="fill" style="--fill-width:${fillWidth}%; --bar-color:${barColor}"></div></div>
           ${percent > 100 ? `<div class="warning"><ha-icon icon="mdi:alert"></ha-icon><span>24h Dose Exceeded</span></div>` : ""}
           <div class="meta">
             ${this.config.show_amount_in_last24h ? `<span><span class="label">Amount 24h:</span> ${this._formatMg(total)} / ${this._formatMg(max)}</span>` : ""}
@@ -122,6 +123,25 @@ class ChildDosageCard extends HTMLElement {
     button.disabled = true;
     try { await this._hass.callService("child_medication_dosage", "clear_history", { child_id: childId, medicine }); }
     finally { button.disabled = false; }
+  }
+
+  _showDoseLog(serializedLog) {
+    const log = this._parseDoseLog(serializedLog);
+    if (!log.length) {
+      window.alert("No doses recorded in the last 48 hours.");
+      return;
+    }
+    const lines = log.map((event) => `• ${this._formatDateTime(event.given_at)} — ${this._formatMg(event.dose_mg)}`);
+    window.alert(`Doses in last 48 hours:\n\n${lines.join("\n")}`);
+  }
+
+  _parseDoseLog(serializedLog) {
+    try {
+      const log = JSON.parse(serializedLog || "[]");
+      return Array.isArray(log) ? log : [];
+    } catch (_error) {
+      return [];
+    }
   }
 
   _childAgeWeight(dobIso, weightKg) {

--- a/custom_components/child_medication_dosage/sensor.py
+++ b/custom_components/child_medication_dosage/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from datetime import timedelta
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
@@ -95,6 +96,12 @@ class MedicationDoseSensor(SensorEntity):
             self._medicine, date_of_birth, self._child[CONF_WEIGHT_KG], now
         )
         events = self._history.events_for(self._child[ATTR_CHILD_ID], self._medicine, now)
+        events_48h = self._history.events_for(
+            self._child[ATTR_CHILD_ID],
+            self._medicine,
+            now,
+            window=timedelta(hours=48),
+        )
         last = self._history.last_event(self._child[ATTR_CHILD_ID], self._medicine)
         total = round(sum(event.dose_mg for event in events), 1)
         percent = 0 if rule.max_24h_mg <= 0 else min(100, round(total / rule.max_24h_mg * 100))
@@ -110,6 +117,10 @@ class MedicationDoseSensor(SensorEntity):
             ATTR_MAX_DOSES_24H: rule.max_doses_24h,
             ATTR_PERCENT_USED: percent,
             ATTR_LAST_DOSE_AT: last.given_at.isoformat() if last else None,
+            "dose_log_48h": [
+                {"dose_mg": event.dose_mg, "given_at": event.given_at.isoformat()}
+                for event in sorted(events_48h, key=lambda event: event.given_at, reverse=True)
+            ],
             "rule_note": rule.note,
             "weight_kg": self._child[CONF_WEIGHT_KG],
         }


### PR DESCRIPTION
### Motivation
- Provide a quick way to view a list of doses given in the last 48 hours by tapping the dosage progress bar in the Lovelace card.

### Description
- Extend sensor summary to include a new `dose_log_48h` attribute containing ordered dose entries (`dose_mg` and `given_at` ISO timestamps) from the last 48 hours. (`custom_components/child_medication_dosage/sensor.py`)
- Make the dosage progress bar tappable and store the 48h log as a JSON-encoded `data-log` attribute on the bar element. (`custom_components/child_medication_dosage/frontend/child-dosage-card.js`)
- Add event listener wiring for `.bar[data-log]` and implement `_showDoseLog` and `_parseDoseLog` methods to parse the log and display a simple alert listing timestamps and amounts, with an empty-state message when no doses exist.
- Small UI touch: set `cursor: pointer` and `title` on the bar to indicate interactivity.

### Testing
- `python -m compileall custom_components/child_medication_dosage` completed successfully and compiled the modified Python module without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff73a0603083298d7682a813edb88d)